### PR TITLE
Change read/write to read-only for reading ref

### DIFF
--- a/TIDDIT_clustering.py
+++ b/TIDDIT_clustering.py
@@ -635,10 +635,10 @@ def determine_ploidy(args,chromosomes,coverage_data,Ncontent,sequence_length,lib
 #compute the GC content of the bins, and find which bins contain too many N
 def retrieve_N_content(args):
 	if not args.ref.endswith(".gz"):
-		with open(args.ref, 'r+') as f:
+		with open(args.ref, 'r') as f:
 			sequence=f.read().split(">")
 	else:
-		with gzip.open(args.ref, 'r+') as f:
+		with gzip.open(args.ref, 'r') as f:
 			sequence=f.read().split(">")
 
 	del sequence[0]


### PR DESCRIPTION
We are running into the following exception:                                                                                                                                
                                                                                                                                                                            
    working on seqence chrUn_JTFH01001997v1_decoy                                                                                                                           
    working on seqence chrUn_JTFH01001998v1_decoy                                                                                                                           
    variant calling time consumption= 14s                                                                                                                                   
    Traceback (most recent call last):                                                                                                                                      
      File "/TIDDIT/TIDDIT.py", line 54, in <module>                                                                                                                        
        TIDDIT_clustering.cluster(args)                                                                                                                                     
      File "/TIDDIT/TIDDIT_clustering.py", line 668, in cluster                                                                                                             
        Ncontent,sequence_length=retrieve_N_content(args)                                                                                                                   
      File "/TIDDIT/TIDDIT_clustering.py", line 638, in retrieve_N_content                                                                                                  
        with open(args.ref, 'r+') as f:                                                                                                                                     
    IOError: [Errno 13] Permission denied: '/shares/hii/bioinfo/ref/gotcloud/hs38DH-db142-v1/hs38DH.fa'                                                                     

Removing the + from r+ mode allows reading files without having write permission.